### PR TITLE
Suggest changes to the sample profile

### DIFF
--- a/generic/0.1/profile.json
+++ b/generic/0.1/profile.json
@@ -24,7 +24,7 @@
             "required": true
         },
         "External-Identifier": {
-            "required": true
+            "required": false
         },
         "External-Description": {
             "required": true

--- a/generic/0.1/profile.json
+++ b/generic/0.1/profile.json
@@ -11,6 +11,12 @@
         "Bagging-Date": {
             "required": true
         },
+        "Source-Organization": {
+            "required": false
+        },
+        "Contact-Name": {
+            "required": false
+        },
         "Contact-Phone": {
             "required": false
         },

--- a/generic/0.1/profile.json
+++ b/generic/0.1/profile.json
@@ -40,7 +40,7 @@
         }    	 
     },
     "Manifests-Required": [
-        "md5"
+        "sha256"
     ],
     "Allow-Fetch.txt": true,
     "Serialization": "optional",
@@ -56,7 +56,7 @@
     ],
 
     "Tag-Manifests-Required": [
-        "md5"
+        "sha256"
     ],
     "Tag-Files-Required": [
         "metadata/datacite.xml"


### PR DESCRIPTION
I'd like to suggest the following changes to the sample profile:
1. Add optional elements `Source-Organization` and `Contact-Name` to the Bag-Info.
2. Change the required checksum algorithm from `md5` to `sha256`.
3. Change the element `External-Identifier` in the Bag-Info from required to optional.

Rationale:
1. Mostly cosmetic.  As far as I understand it, optional elements in the Bag-Info are suggestions only.  The organization of origin is useful meta information. A contact email should be accompanied by a name. So these suggestions seem reasonable to me.
2. MD5 is obsolete.  The (current draft version of the) BagIt File Packaging Format specification acknowledges on md5 and sha1 in Section 2.4: "The authors recognize that, compared with newer algorithms [RFC6234], these two algorithms now have well-known vulnerabilities that render them inadequate for applications requiring secure change detection." The default for common bagit creation tools (bagit-python) is to create `sha256` and `sha512`.
3. We explicitly allow payload that does not have a DOI. So what should the creator of the package put here if the content does not have a DOI?

Let me add on the last two items: We explicitly discourage the proliferation of new profiles and ask to reuse existing ones. But then, our sample profile should set a good example and seek to be suitable for most use cases. It is therefore a problem, if we put requirements in there that cannot easily be fulfilled in all cases.